### PR TITLE
Update installation.md to have quotes on square brackets

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -4,11 +4,11 @@ To install the `unified_planning` run the command: ``pip install unified-plannin
 
 You can also install some other engines, for example `ENHSP` with the `unified-planning`, by running ``pip install unified-planning[enhsp]``
 
-To install ALL the default engines run: ``pip install unified-planning[engines]``
+To install ALL the default engines run: ``pip install "unified-planning[engines]"``
 
-To install plotting functionalities run: ``pip install unified-planning[plot]``
+To install plotting functionalities run: ``pip install "unified-planning[plot]"``
 
-To install gRPC functionalities run: ``pip install unified-planning[grpc]``
+To install gRPC functionalities run: ``pip install "unified-planning[grpc]"``
 
 
 ## Prerequisites


### PR DESCRIPTION
When there are no double quotes on pip install with square brackets it throws error: `no matches found: unified-planning[engines]`

Resolve this by adding double quotes in the installation doc file.